### PR TITLE
Open access to the `ref` of the wrapped react-leaflet component.

### DIFF
--- a/src/decorator.js
+++ b/src/decorator.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 
-const { node } = PropTypes;
+const { node, func } = PropTypes;
 
 export default function decorate(componentName) {
 	class Decorated extends Component {
@@ -19,13 +19,15 @@ export default function decorate(componentName) {
 			if (!this.state.loaded) return null;
 
 			const { ClientComponent } = this;
-			const { children, ...rest } = this.props;
-			return <ClientComponent {...rest}>{children}</ClientComponent>;
+			const { children, leafletRef, ...rest } = this.props;
+
+			return <ClientComponent {...rest} ref={leafletRef}>{children}</ClientComponent>;
 		}
 	}
 
 	Decorated.propTypes = {
-		children: node
+		children: node,
+		leafletRef: func
 	};
 
 	return Decorated;


### PR DESCRIPTION
I've had a use case of needing to call `invalidateSize` on the `Map` component.
This required using the `ref` property of the decorated component.
This approach should allow easy access to Leaflet instances that `react-leaflet`'s author exposed in the library.
Do you think it's acceptable? Or perhaps it is possible to get this in another way that I missed? 
