### PR TITLE
Attach leaflet element

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ To forward reference, pass to `leafletRef`:
 </Map>
 ```
 
+If you do not provide `leafletRef`, wrappers will instead create their own ref and set the property `leafletElement` on the instance when it becomes available, so setting a `ref` prop will still work, however note that since this only occurs late in the render cycle, `leafletElement` may still be undefined when attempting to access it from the `ref`, so it is recommended to check that `ref.leafletElement` exists before attempting to invoke properties or methods on it.
+
 ## Troubleshooting custom `react-leaflet` components / render prop support
 
 Some components, such as [react-leaflet-markercluster][markercluster-url], make use of `componentWillMount` and so cannot be used directly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-universal",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-universal",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Simple wrapper around react-leaflet for painless universal integration",
   "main": "dist/index.js",
   "scripts": {

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -11,6 +11,8 @@ export default function decorate(componentName) {
 			super(props);
 			this.state = { loaded: false };
 			this.constructor.displayName = displayName;
+			this._leafletRef = React.createRef();
+			this._getRef = () => this.props.leafletRef || this._leafletRef;
 		}
 
 		componentDidMount() {
@@ -18,15 +20,22 @@ export default function decorate(componentName) {
 			this.ClientComponent = require('react-leaflet')[componentName];
 		}
 
+		componentDidUpdate() {
+			const ref = this._getRef();
+			if (ref && ref.current) {
+				this.leafletElement = ref.current.leafletElement;
+			}
+		}
+
 		render() {
 			if (!this.state.loaded) return null;
 
 			const { ClientComponent } = this;
-			const { children, leafletRef, ...rest } = this.props;
+			const { children, ...rest } = this.props;
 			const childComponents = typeof children === 'function' ? children() : children;
 
 			return (
-				<ClientComponent {...rest} ref={leafletRef}>
+				<ClientComponent {...rest} ref={this._getRef()}>
 					{ childComponents }
 				</ClientComponent>
 			);

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -22,7 +22,7 @@ export default function decorate(componentName) {
 
 		componentDidUpdate() {
 			const ref = this._getRef();
-			if (ref && ref.current) {
+			if (ref && ref.current && this.leafletElement !== ref.current.leafletElement) {
 				this.leafletElement = ref.current.leafletElement;
 			}
 		}


### PR DESCRIPTION
Make wrapper create their own `ref` forwarding if `leafletRef` is not specified. This is convenient, but note the caveat that `leafletElement` is still not guaranteed to exist until the actual underlying component is rendered.